### PR TITLE
Fix handling of zero velocity note on messages

### DIFF
--- a/software/Src/main.c
+++ b/software/Src/main.c
@@ -358,11 +358,21 @@ int main(void)
 					char vel = midiBuffer[2];
 
 					uint16_t freq = pow(2,(key-0x45)/12.0)*440.0;
+
 					curChannel = midiBuffer[0] & 0xF;
-					freqs[curChannel] = freq;
 
+					// Note on with a velocity of 0x00 is the same as a note off message. MIDI Spec: 
+					// "A receiver must be capable of recognizing either method of turning off a note, and should treat them identically."
+					if (vel == 0) {
+						if (freqs[curChannel] == freq)
+							freqs[curChannel] = 0;
+					} else {
+						freqs[curChannel] = freq;
+					}
+					
+				}
 
-				} if ((midiBuffer[0] &0xF0) == 0x80) { // Note off, 2 data bytes
+				if ((midiBuffer[0] & 0xF0) == 0x80) { // Note off, 2 data bytes
 					char key = midiBuffer[1];
 					char vel = midiBuffer[2];
 


### PR DESCRIPTION
Hi Niklas,

this PR fixes handling of MIDI messages according to the MIDI 1.0 spec.

I have a Casio keyboard which outputs MIDI messages in this format and always sends Note On messages, even for Note Off-events. 

This PR has been tested with other midi music files, I couldn't notice any bad side effects of these changes. 
