### PR TITLE
Fix bug that the TS can not play back the same tone twice

### DIFF
--- a/software/Src/main.c
+++ b/software/Src/main.c
@@ -311,6 +311,7 @@ int main(void)
 		} else if (curTone0 < 20 && curTone0 != lastTone0) {
 			TIM14->CR1 &= ~(1UL);
       curPeriode0 = 0;
+      lastTone0 = 0;
 
 			HAL_GPIO_WritePin(LED_FAULT_GPIO, LED_FAULT_PIN, RESET);
 		}
@@ -325,6 +326,7 @@ int main(void)
 		} else if (curTone1 < 20 && curTone1 != lastTone1) {
 			TIM15->CR1 &= ~(1UL);
       curPeriode1 = 0;
+      lastTone1 = 0;
 		}
 
 		if ((HAL_GetTick() - noteTimeout) > 1000) {


### PR DESCRIPTION
Fixed the bug that the Tesla was unable to play the same note twices.

Steps to reproduce:
* Connect Tesla to software MIDI keyboard
* Try to play the same note twice with a short break
Result:
* First time the note is played, second time the tesla stays silent.

Fix:
If the note was switched off with curTone = 0; the variable lastTone was not changed to 0. This will lead to the Timers not getting set with the correct frequency, curTone will equal lastTone.